### PR TITLE
Bugfix for provider codes not working

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "code-bing",
   "displayName": "CodeBing",
   "description": " Extension to search for selected text in the internet.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "SirTobi",
   "author": {
     "name": "Tobias Kahlert (a.k.a SirTobi)"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,5 +2,5 @@ export function isNullOrEmpty(s: string): boolean {
 	return s == null || s == "";
 }
 export function startsWith(s: string, startsWith: string) {
-	return s != null && startsWith != null && s.indexOf(startsWith) == 0;
+	return !isNullOrEmpty(s) && !isNullOrEmpty(startsWith) && s.indexOf(startsWith) == 0;
 }


### PR DESCRIPTION
Did not catch this bug in time (sorry)....

Turns out "foo".indexOf("") == 0 Woops
