### PR TITLE
Add windows specific shortcut sequence

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "keybindings": [
       {
         "command": "codebing.search",
-        "key": "ctrl+alt+F"
+        "key": "ctrl+alt+f",
+        "win": "shift+alt+f"
       }
     ]
   },


### PR DESCRIPTION
Ctrl+Alt+ keybindings should not be used by default under Windows.
![JS console](https://i.imgur.com/3desd4t.png)
