### PR TITLE
#0 php + mdn + py search providers added

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ __Note__ that setting this option will overwrite these defaults.
 	"twit": "https://twitter.com/search?q={query}",
 	"gh": "https://github.com/search?utf8=✓&q={query}",
 	"so": "https://stackoverflow.com/search?q={query}",
-        "php" : "http://php.net/manual-lookup.php?pattern={query}&scope=quickref",
+        "php" : "https://php.net/manual-lookup.php?pattern={query}&scope=quickref",
         "mdn": "https://developer.mozilla.org/en-US/search?q={query}&highlight=true",
         "py": "https://www.python.org/search/?q={query}"
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ __Note__ that setting this option will overwrite these defaults.
 	"yt": "https://www.youtube.com/results?search_query={query}",
 	"twit": "https://twitter.com/search?q={query}",
 	"gh": "https://github.com/search?utf8=✓&q={query}",
-	"so": "https://stackoverflow.com/search?q={query}"
+	"so": "https://stackoverflow.com/search?q={query}",
+        "php" : "http://php.net/manual-lookup.php?pattern={query}&scope=quickref",
+        "mdn": "https://developer.mozilla.org/en-US/search?q={query}&highlight=true",
+        "py": "https://www.python.org/search/?q={query}"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -50,8 +50,11 @@
             "yt": "https://www.youtube.com/results?search_query={query}",
             "twit": "https://twitter.com/search?q={query}",
             "gh": "https://github.com/search?utf8=✓&q={query}",
-            "so": "https://stackoverflow.com/search?q={query}"
-          }
+            "so": "https://stackoverflow.com/search?q={query}",
+            "php" : "http://php.net/manual-lookup.php?pattern={query}&scope=quickref",
+            "mdn": "https://developer.mozilla.org/en-US/search?q={query}&highlight=true",
+            "py": "https://www.python.org/search/?q={query}"
+	}
         },
         "codebing.useDefaultProviderOnly": {
           "title": "Use default search provider only.",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
             "twit": "https://twitter.com/search?q={query}",
             "gh": "https://github.com/search?utf8=✓&q={query}",
             "so": "https://stackoverflow.com/search?q={query}",
-            "php" : "http://php.net/manual-lookup.php?pattern={query}&scope=quickref",
+            "php" : "https://php.net/manual-lookup.php?pattern={query}&scope=quickref",
             "mdn": "https://developer.mozilla.org/en-US/search?q={query}&highlight=true",
             "py": "https://www.python.org/search/?q={query}"
 	}


### PR DESCRIPTION
PHP : http://php.net/manual-lookup.php?pattern={query}&scope=quickref
MDN: https://developer.mozilla.org/en-US/search?q={query}&highlight=true
Python: https://www.python.org/search/?q={query}
